### PR TITLE
Fixed Column to ColumnName

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lingualeo/expert-sender-api",
+    "name": "f1r3starter/expert-sender-api",
     "description": "Simple API for expert sender service",
     "license": "MIT",
     "authors": [

--- a/src/LinguaLeo/ExpertSender/Chunks/OrderByChunk.php
+++ b/src/LinguaLeo/ExpertSender/Chunks/OrderByChunk.php
@@ -30,7 +30,7 @@ EOD;
     public function getText()
     {
         $text = [];
-        $text[] = (new SimpleChunk('Column', $this->orderBy->getColumnName()))->getText();
+        $text[] = (new SimpleChunk('ColumnName', $this->orderBy->getColumnName()))->getText();
         $text[] = (new SimpleChunk('Direction', $this->orderBy->getDirection()))->getText();
         return sprintf(self::PATTERN, implode(PHP_EOL, $text));
     }


### PR DESCRIPTION
According to example from here: http://man…ual.expertsender.ru/metody/tablitsy-dannykh/poluchit-dannye-iz-tablitsy parameter "Column" should be renamed to "ColumnName"